### PR TITLE
Proposal 716

### DIFF
--- a/template/node8-express-armhf/index.js
+++ b/template/node8-express-armhf/index.js
@@ -79,8 +79,8 @@ var middleware = (req, res) => {
     handler(fnEvent, fnContext, cb);
 };
 
-app.post('/', middleware);
-app.get('/', middleware);
+app.post('/*', middleware);
+app.get('/*', middleware);
 
 const port = process.env.http_port || 3000;
 

--- a/template/node8-express-armhf/index.js
+++ b/template/node8-express-armhf/index.js
@@ -20,6 +20,7 @@ class FunctionEvent {
         this.headers = req.headers;
         this.method = req.method;
         this.query = req.query;
+        this.path = req.path;
     }
 }
 

--- a/template/node8-express/index.js
+++ b/template/node8-express/index.js
@@ -79,8 +79,8 @@ var middleware = (req, res) => {
     handler(fnEvent, fnContext, cb);
 };
 
-app.post('/', middleware);
-app.get('/', middleware);
+app.post('/*', middleware);
+app.get('/*', middleware);
 
 const port = process.env.http_port || 3000;
 

--- a/template/node8-express/index.js
+++ b/template/node8-express/index.js
@@ -20,6 +20,7 @@ class FunctionEvent {
         this.headers = req.headers;
         this.method = req.method;
         this.query = req.query;
+        this.path = req.path;
     }
 }
 


### PR DESCRIPTION
Implement proposal 716, pass full paths to functions

This changes the default route to be catch-all, so that it will match any path forwarded by the Gateway and watchdog.

This also adds a `path` member to the event object for use in the handler.

Tested by deploying example functions which echo back the path.

(NOTE: The Dockerfile reference to the of-watchdog binary will also need updated, but that is not a change I can make, since the of-watchdog binary is not available yet. For testing I used a locally built of-watchdog.)

Signed-off-by: Thomas E Lackey telackey@bozemanpass.com